### PR TITLE
Fix some broken links to the Ruby repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ on media that do not promote community-driven updates. So I'm writing a new
 guide that doesn't suck and is on Github so you too can help make it not suck.
 
 [a]: http://clalance.blogspot.com/2011/01/writing-ruby-extensions-in-c-part-1.html
-[b]: https://raw.githubusercontent.com/ruby/ruby/trunk/README.EXT
+[b]: https://raw.githubusercontent.com/ruby/ruby/master/doc/extension.rdoc
 [c]: http://blog.jacius.info/ruby-c-extension-cheat-sheet/
 [d]: http://hugopl.github.io/2014/04/09/Embedding-Ruby-2.1-into-a-Cpp-application.html
 [e]: https://gist.github.com/jefftrull/1305431

--- a/_posts/2010-01-01-c.markdown
+++ b/_posts/2010-01-01-c.markdown
@@ -82,7 +82,7 @@ type?". There are a couple macros for performing this test, and both take a
 [`T_` constant][datatypes] corresponding to the Ruby class you're
 testing for e.g. `T_STRING`, `T_ARRAY`, etc.
 
-[datatypes]: https://github.com/ruby/ruby/blob/trunk/doc/extension.rdoc#data-types
+[datatypes]: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#label-Data+Types
 
 {% highlight c %}
 {% include c/checktype.h %}
@@ -889,7 +889,7 @@ some poor recommendations (in my opinion), but it is also a little more
 exhaustive on certain topics. In many cases this is because I intentionally
 skipped something that I either found not useful or better documented elsewhere.
 
-[readme]: https://github.com/ruby/ruby/blob/trunk/doc/extension.rdoc
+[readme]: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc
 
 ### Headers ###
 
@@ -996,5 +996,5 @@ download all of the code examples.
 
 [^tdata]: Or use `T_DATA` if the object [wraps a C pointer](#data).
 
-[control]: https://github.com/ruby/ruby/blob/trunk/doc/extension.rdoc#control-structure
+[control]: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#label-Control+Structure
 [bug2]: https://bugs.ruby-lang.org/issues/10466

--- a/_posts/2013-01-01-extend.markdown
+++ b/_posts/2013-01-01-extend.markdown
@@ -135,5 +135,5 @@ subdirectories of `ext/` and pass all of the `extconf.rb`s to the spec.
 
 [^rbg]: [http://guides.rubygems.org/gems-with-extensions/](http://guides.rubygems.org/gems-with-extensions/)
 
-[globals]: https://github.com/ruby/ruby/blob/trunk/doc/extension.rdoc#prepare-extconfrb
-[makefile]: https://github.com/ruby/ruby/blob/trunk/doc/extension.rdoc#generate-makefile
+[globals]: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#label-Prepare+extconf.rb
+[makefile]: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc#label-Generate+Makefile


### PR DESCRIPTION
Hello,

First, thank you very much for this pretty cool documentation on C extensions. ❤️ 
 
This pull request fixes some broken links as Ruby is now using Git, the default branch is no longer `trunk` but `master`. It also fixes some broken anchors in links.

Have a nice day.