### PR TITLE
Fix misleading comment in methodr.h

### DIFF
--- a/_includes/c/methodr.h
+++ b/_includes/c/methodr.h
@@ -1,6 +1,6 @@
 /* the usual */
 rb_define_method(klass, "my_method", my_method, argc);
-/* or, like a toplevel def (by defining a private method in Kernel) */
+/* or, like a toplevel def (by defining a public method in Kernel) */
 rb_define_global_function("my_method", my_method, argc);
 
 /* or, with access control */

--- a/_includes/c/methodr.h
+++ b/_includes/c/methodr.h
@@ -1,6 +1,6 @@
 /* the usual */
 rb_define_method(klass, "my_method", my_method, argc);
-/* or, like a toplevel def (by defining a public method in Kernel) */
+/* or, like a toplevel def (by defining a method in Kernel) */
 rb_define_global_function("my_method", my_method, argc);
 
 /* or, with access control */


### PR DESCRIPTION
As far as I understand, rb_define_global_function defines a public method and not a private one